### PR TITLE
updating cart scope to be inside then

### DIFF
--- a/assets/js/theme/common/bundlebutton.js
+++ b/assets/js/theme/common/bundlebutton.js
@@ -46,15 +46,21 @@ function getCart(url) {
 };
 
 const bundleAdd = () => {
-    let cart = getCart('/api/storefront/carts?include=lineItems.digitalItems.options,lineItems.physicalItems.options')
-        .then(data => console.log(JSON.stringify(data)))
-                
-    let cartId = cart[0].id;
+    getCart('/api/storefront/carts?include=lineItems.digitalItems.options,lineItems.physicalItems.options')
+    .then(cart => {
+        console.log(JSON.stringify(cart))
+        // If the data did not return the ID we need to add an item log and return early
+        if(!cart || !cart[0] || !cart[0].id){
+            console.warn('getCart did not return id');
+            return;
+        }
+            
+        let cartId = cart[0].id;
 
-    addCartItem(cartURL, cartId, bundleItems)
-      .then(data => console.log(JSON.stringify(data)))
-      .catch(error => console.error(error));
-
+        addCartItem(cartURL, cartId, bundleItems)
+            .then(data => console.log(JSON.stringify(data)))
+            .catch(error => console.error(error));
+    });
 };
 
 


### PR DESCRIPTION
This corrects a scope issue with data access for `.then()` chains.

With Promises once you start using `then()` you have to stay inside there. It's a little better than original JS callbacks, but not quite as nice as [await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await).  Note, with `await` you'll need a trasnpiler to get it working in the browser.

The value of `cart` was the promise, not the data that the API was returning.  Since there's already a `then()` after the promise we have access to the data there and can continue chaining these bad boys together.